### PR TITLE
Bug fixes for manga dataset creation

### DIFF
--- a/scripts/manga/build_parent_sample.py
+++ b/scripts/manga/build_parent_sample.py
@@ -210,7 +210,7 @@ def process_single_plateifu(args: tuple) -> dict:
         # pad rest with 0s
         flux = flux.reshape(nwave, nspaxels)
         ivar = np.pad(hdulist['IVAR'].data, pad_arr).reshape(nwave, nspaxels)
-        mask = np.pad(hdulist['FLUX'].data, pad_arr, constant_values=1024).reshape(nwave, nspaxels)
+        mask = np.pad(hdulist['MASK'].data, pad_arr, constant_values=1024).reshape(nwave, nspaxels)
         lsf = np.pad(hdulist['LSFPOST'].data, pad_arr).reshape(nwave, nspaxels)
 
         wave = hdulist['WAVE'].data.astype(np.float32)


### PR DESCRIPTION
This PR closes #100.  It fixes a few bugs when creating the hugging face dataset.  The following issues were fixed:

- The spaxel 1d array data for `flux`, `ivar`, `mask`, `lsf`, and `lambda` were not in the proper shape of `[1, nwave]`
- The incorrect data extension was accessed for the `MASK` arrays.  This was causing some improper int/float conversions.
- The `spaxel_idx` had the incorrect integer type.  

This will require regeneration of the manga healpix files from the original dataset.  Once re-run, the code snippet from #100 should run.  Additional checks may be needed to ensure everything else in the hf dataset looks ok.   

 
