### PR TITLE
Modifications needed for HF sync 

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,4 +1,4 @@
-ASTROPILE_ROOT := /mnt/ceph/users/polymathic/AstroPile_v1
+ASTROPILE_ROOT := /mnt/ceph/users/polymathic/MultimodalUniverse_staging
 DATA_DIR := /mnt/ceph/users/polymathic/external_data/astro
 
 .PHONY: all apogee desi sdss decals plasticc jwst gz10 hsc vipers gaia desi_provabgs yse des_y3_sne_ia swift_sne_ia ps1_sne_ia snls foundation btsbot manga tess

--- a/scripts/btsbot/btsbot.py
+++ b/scripts/btsbot/btsbot.py
@@ -68,13 +68,11 @@ _HOMEPAGE = "https://zenodo.org/records/10839691"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "10.0.0"
+_VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
     'jd',
     'diffmaglim',
-    'ra',
-    'dec',
     'magpsf',
     'sigmapsf',
     'chipsf',
@@ -154,7 +152,6 @@ _INT_FEATURES = [
     'nmtchps',
     'nnotdet',
     'N',
-    'healpix',
 ]
 
 _BOOL_FEATURES = [
@@ -180,9 +177,9 @@ class BTSbot(datasets.GeneratorBasedBuilder):
             name="BTSbot", 
             version=VERSION,
             data_files=DataFilesPatternsDict.from_patterns({
-                'train': ['./data/healpix=*/train_001-of-001.hdf5'],
-                'val': ['./data/healpix=*/val_001-of-001.hdf5'],
-                'test': ['./data/healpix=*/test_001-of-001.hdf5'],
+                'train': ['data/healpix=*/train_001-of-001.hdf5'],
+                'val': ['data/healpix=*/val_001-of-001.hdf5'],
+                'test': ['data/healpix=*/test_001-of-001.hdf5'],
                 }),
             description="BTSbot dataset with train, val, and test splits."
             ),
@@ -268,10 +265,10 @@ class BTSbot(datasets.GeneratorBasedBuilder):
                     example = {
                         'image': [
                             {
-                                'band': data['band'],
+                                'band': data['band'][i],
                                 'view': view,
                                 'array': data['image_triplet'][i, :, :, j],
-                                'scale': data['image_scale'],
+                                'scale': data['image_scale'][i],
                             }
                             for j, view in enumerate(self._views)
                         ]

--- a/scripts/btsbot/build_parent_sample.py
+++ b/scripts/btsbot/build_parent_sample.py
@@ -69,7 +69,7 @@ def main(args):
     for healpix in tqdm(unique_healpix):
         hp_dir_path = os.path.join(
             args.output_dir,
-            f'healpix={str(healpix).zfill(healpix_num_digits)}'
+            f'data/healpix={str(healpix).zfill(healpix_num_digits)}'
             )
         os.makedirs(hp_dir_path, exist_ok=True)
         for ind, (img_file, meta_file) in enumerate(zip(img_files, meta_files)):
@@ -88,7 +88,7 @@ def main(args):
 
             hdf5_file_path = os.path.join(
                 args.output_dir,
-                f'healpix={str(healpix).zfill(healpix_num_digits)}',
+                f'data/healpix={str(healpix).zfill(healpix_num_digits)}',
                 f'{splits[ind]}_001-of-001.hdf5'
                 )
             with h5py.File(hdf5_file_path, 'w') as hdf5_file:
@@ -120,7 +120,7 @@ if __name__ == '__main__':
         'output_dir',
         type=str,
         help='Path to the output directory',
-        default='./data'
+        default='.'
         )
     parser.add_argument(
         '--dirty',

--- a/scripts/btsbot/test.sh
+++ b/scripts/btsbot/test.sh
@@ -27,8 +27,6 @@ for split in ('train', 'val', 'test'):
     print(f'loaded {split} split from dataset with {len(dset_split)} examples')
     example = next(iter(dset_split))
     object_id = example['object_id']
-    ra = example['ra']
-    dec = example['dec']
     print('Some example data from the first example:')
     print(f'object_id={object_id}, ra={ra}, dec={dec}')
     print()

--- a/scripts/btsbot/test.sh
+++ b/scripts/btsbot/test.sh
@@ -10,7 +10,7 @@ else
 fi
 
 # First build the parent sample and save both raw and H5 to current directory
-if python build_parent_sample.py ./data_orig ./data; then
+if python build_parent_sample.py ./data_orig .; then
     echo "Build parent sample for BTSbot successful"
     echo ""
 else

--- a/scripts/btsbot/test.sh
+++ b/scripts/btsbot/test.sh
@@ -28,7 +28,7 @@ for split in ('train', 'val', 'test'):
     example = next(iter(dset_split))
     object_id = example['object_id']
     print('Some example data from the first example:')
-    print(f'object_id={object_id}, ra={ra}, dec={dec}')
+    print(f'object_id={object_id}')
     print()
 "; then
     echo "Load dataset for BTSbot successful"

--- a/scripts/cfa/cfa.py
+++ b/scripts/cfa/cfa.py
@@ -18,14 +18,14 @@ import datasets
 from datasets import Features, Value, Sequence
 from datasets.data_files import DataFilesPatternsDict
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _HOMEPAGE = "https://lweb.cfa.harvard.edu/supernova/"
 _LICENSE = "CC BY 4.0"
 
 # Features common across all CFA datasets
 _STR_FEATURES = ["object_id", "obj_type"]
-_FLOAT_FEATURES = ["ra", "dec"]
+_FLOAT_FEATURES = []
 
 # Dataset-specific descriptions and citations
 _DESCRIPTIONS = {

--- a/scripts/chandra/chandra.py
+++ b/scripts/chandra/chandra.py
@@ -63,7 +63,7 @@ _HOMEPAGE = "https://cxc.cfa.harvard.edu/csc/"
 
 _LICENSE = ""
 
-_VERSION = "2.1.0"
+_VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
     "flux_aper_b",

--- a/scripts/csp/csp.py
+++ b/scripts/csp/csp.py
@@ -53,7 +53,7 @@ _HOMEPAGE = "https://csp.obs.carnegiescience.edu/"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _STR_FEATURES = [
     "object_id",
@@ -76,7 +76,7 @@ class CSPIDR3(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="csp_dr3",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["./*/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["csp/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
             description="Light curves from CSP-I DR3",
         ),
     ]

--- a/scripts/des_y3_sne_ia/build_parent_sample.py
+++ b/scripts/des_y3_sne_ia/build_parent_sample.py
@@ -143,13 +143,13 @@ def main(args):
     healpix_num_digits = len(str(hp.nside2npix(16)))
     for healpix in unique_healpix:
         healpix = str(healpix).zfill(healpix_num_digits)
-        os.makedirs(os.path.join(args.output_dir, f'healpix={healpix}'), exist_ok=True)
+        os.makedirs(os.path.join(args.output_dir, f'des_y3_sne_ia/healpix={healpix}'), exist_ok=True)
 
     # Save data as hdf5 grouped into directories by healpix
     for i in range(num_examples):
         healpix = str(metadata['healpix'][i]).zfill(healpix_num_digits)
         object_id = metadata['object_id'][i]
-        path = os.path.join(args.output_dir, f'healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
+        path = os.path.join(args.output_dir, f'des_y3_sne_ia/healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
         
         with h5py.File(path, 'w') as hdf5_file:
             # Determine which keys are used for dynamically used metadata

--- a/scripts/des_y3_sne_ia/des_y3_sne_ia.py
+++ b/scripts/des_y3_sne_ia/des_y3_sne_ia.py
@@ -74,8 +74,6 @@ _STR_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "ra", 
-    "dec", 
     "redshift",
     "host_log_mass"
 ]
@@ -90,7 +88,7 @@ class DESY3SNIa(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="des_y3_sne_ia",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["./healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["des_y3_sne_ia/healpix=*/*.hdf5"]}), 
             description="Light curves from  DES Y3",
         ),
     ]

--- a/scripts/desi/desi.py
+++ b/scripts/desi/desi.py
@@ -61,7 +61,7 @@ _HOMEPAGE = "https://data.desi.lbl.gov/doc"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 # Full data model here:
 # https://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/zpix-SURVEY-PROGRAM.html
@@ -71,8 +71,8 @@ _BOOL_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "z",
-    "zerr",
+    "Z",
+    "ZERR",
     "EBV",
     "FLUX_G",
     "FLUX_R",

--- a/scripts/desi_provabgs/desi_provabgs.py
+++ b/scripts/desi_provabgs/desi_provabgs.py
@@ -83,7 +83,7 @@ _BOOL_FEATURES = [
 class PROVABGS(datasets.GeneratorBasedBuilder):
     """TODO: Short description of my dataset."""
 
-    VERSION = datasets.Version("1.1.0")
+    VERSION = _VERSION
 
     BUILDER_CONFIGS = [
         datasets.BuilderConfig(name="provabgs",

--- a/scripts/foundation/build_parent_sample.py
+++ b/scripts/foundation/build_parent_sample.py
@@ -137,13 +137,13 @@ def main(args):
     healpix_num_digits = len(str(hp.nside2npix(_healpix_nside)))
     for healpix in unique_healpix:
         healpix = str(healpix).zfill(healpix_num_digits)
-        os.makedirs(os.path.join(args.output_dir, f'healpix={healpix}'), exist_ok=True)
+        os.makedirs(os.path.join(args.output_dir, f'foundation_dr1/healpix={healpix}'), exist_ok=True)
 
     # Save data as hdf5 grouped into directories by healpix
     for i in range(num_examples):
         healpix = str(metadata['healpix'][i]).zfill(healpix_num_digits)
         object_id = metadata['object_id'][i]
-        path = os.path.join(args.output_dir, f'healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
+        path = os.path.join(args.output_dir, f'foundation_dr1/healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
         
         with h5py.File(path, 'w') as hdf5_file:
             # Determine which keys are used for dynamically used metadata

--- a/scripts/foundation/foundation.py
+++ b/scripts/foundation/foundation.py
@@ -80,7 +80,7 @@ _HOMEPAGE = "https://github.com/djones1040/Foundation_DR1/tree/master"
 
 _LICENSE = "https://cds.unistra.fr/vizier-org/licences_vizier.html"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _STR_FEATURES = [
     "object_id",
@@ -88,8 +88,6 @@ _STR_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "ra", 
-    "dec", 
     "redshift",
     "host_log_mass"
 ]
@@ -104,7 +102,7 @@ class FoundationDR1(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="foundation_dr1",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["./healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["foundation_dr1/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
             description="Light curves from Foundation DR1",
         ),
     ]

--- a/scripts/gz10/build_parent_sample.py
+++ b/scripts/gz10/build_parent_sample.py
@@ -29,8 +29,6 @@ def process_index(
 
     with h5py.File(output_path, "w") as output_file:
         for key in grouped_data:
-            if key == "redshift":
-                key = "z"
             output_file.create_dataset(key, data=grouped_data[key])
         output_file.create_dataset("object_id", data=grouped_object_ids)
         output_file.create_dataset(

--- a/scripts/gz10/gz10.py
+++ b/scripts/gz10/gz10.py
@@ -62,7 +62,7 @@ _VERSION = "1.0.0"
 class GZ10(datasets.GeneratorBasedBuilder):
     """GZ-10 Catalog loaded with Healpix indices (using NSIDE=16). uint8 images included."""
 
-    VERSION = datasets.Version("0.0.1")
+    VERSION = _VERSION
 
     BUILDER_CONFIGS = [
         datasets.BuilderConfig(
@@ -93,9 +93,7 @@ class GZ10(datasets.GeneratorBasedBuilder):
         features = datasets.Features(
             {
                 "gz10_label": datasets.Value("int32"),
-                "ra": datasets.Value("float32"),
-                "dec": datasets.Value("float32"),
-                "z": datasets.Value("float32"),
+                "redshift": datasets.Value("float32"),
                 "object_id": datasets.Value("string"),
             }
         )
@@ -150,9 +148,7 @@ class GZ10(datasets.GeneratorBasedBuilder):
 
                     example = {
                         "gz10_label": data["ans"][i].astype(np.int32),
-                        "dec": data["dec"][i].astype(np.float32),
-                        "ra": data["ra"][i].astype(np.float32),
-                        "z": data["z"][i].astype(np.float32),
+                        "redshift": data["redshift"][i].astype(np.float32),
                     }
 
                     if (

--- a/scripts/hsc/hsc.py
+++ b/scripts/hsc/hsc.py
@@ -75,7 +75,7 @@ _HOMEPAGE = "https://hsc-release.mtk.nao.ac.jp/doc/"
 # TODO: Add the licence for the dataset here if you can find it
 _LICENSE = "See Acknowledgements / Citation"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
     'a_g',

--- a/scripts/legacysurvey/legacysurvey.py
+++ b/scripts/legacysurvey/legacysurvey.py
@@ -68,7 +68,7 @@ _HOMEPAGE = "https://www.legacysurvey.org/dr10/"
 # TODO: Add the licence for the dataset here if you can find it
 _LICENSE = ""
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
     "EBV",
@@ -104,22 +104,14 @@ class DECaLS(datasets.GeneratorBasedBuilder):
 
     VERSION = _VERSION
 
-    BUILDER_CONFIGS = [
-        datasets.BuilderConfig(
-            name="LegacySurvey",
-            version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns(
-                {"train": ["*/healpix=*/*.hdf5"]}
-            ),
-            description="LegacySurvey DR10 images.",
-        ),        
+    BUILDER_CONFIGS = [     
         datasets.BuilderConfig(name="dr10_south_21", 
                                 version=VERSION, 
                                 data_files=DataFilesPatternsDict.from_patterns({'train': ['dr10_south_21/healpix=*/*.hdf5']}),
                                 description="DR10 images from the southern sky, down to zmag 21"),
     ]
 
-    DEFAULT_CONFIG_NAME = "LegacySurvey"
+    DEFAULT_CONFIG_NAME = "dr10_south_21"
 
     _pixel_scale = 0.262
     _image_size = 160

--- a/scripts/manga/manga.py
+++ b/scripts/manga/manga.py
@@ -81,9 +81,6 @@ class MaNGA(datasets.GeneratorBasedBuilder):
 
         # add metadata features
         features['object_id'] = Value("string")
-        features['ra'] = Value("float32")
-        features['dec'] = Value("float32")
-        features['healpix'] = Value("int16")
         features['z'] = Value("float32")
         features['spaxel_size'] = Value("float32")
         features['spaxel_size_units'] = Value("string")

--- a/scripts/plasticc/build_parent_sample.py
+++ b/scripts/plasticc/build_parent_sample.py
@@ -39,7 +39,7 @@ def save_in_standard_format(args):
         if i % 500 == 0:
             print(f"{dataset_type}:{num} - processing healpix {i}")
 
-        group_filename = output_dir / f"healpix={name}" / f"{dataset_type}_{str(num).zfill(2)}.hdf5"
+        group_filename = output_dir / f"data/healpix={name}" / f"{dataset_type}_{str(num).zfill(2)}.hdf5"
         if group_filename.exists():
             print(f"{group_filename} already exists, skipping...")
             return 1

--- a/scripts/plasticc/plasticc.py
+++ b/scripts/plasticc/plasticc.py
@@ -48,7 +48,7 @@ _HOMEPAGE = "https://zenodo.org/records/2539456"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
         'hostgal_photoz',
@@ -93,16 +93,16 @@ class PLAsTiCC(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="plasticc",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["healpix=*/train*.hdf5"], "test": ["healpix=*/test*.hdf5"]}),
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["data/healpix=*/train*.hdf5"], "test": ["data/healpix=*/test*.hdf5"]}),
             description="train: plasticc train (spectroscopic), test: plasticc test (photometric)",
         ),
         datasets.BuilderConfig(name="train_only",
                                 version=VERSION,
-                                data_files=DataFilesPatternsDict.from_patterns({"train": ["healpix=*/train*.hdf5"]}),
+                                data_files=DataFilesPatternsDict.from_patterns({"train": ["data/healpix=*/train*.hdf5"]}),
                                 description="load train (spectroscopic) data only"),
         datasets.BuilderConfig(name="test_only",
                                 version=VERSION,
-                                data_files=DataFilesPatternsDict.from_patterns({"train": ["healpix=*/test*.hdf5"]}),
+                                data_files=DataFilesPatternsDict.from_patterns({"train": ["data/healpix=*/test*.hdf5"]}),
                                 description="load test (photometric) data only"),
     ]
 

--- a/scripts/ps1_sne_ia/build_parent_sample.py
+++ b/scripts/ps1_sne_ia/build_parent_sample.py
@@ -137,13 +137,13 @@ def main(args):
     healpix_num_digits = len(str(hp.nside2npix(_healpix_nside)))
     for healpix in unique_healpix:
         healpix = str(healpix).zfill(healpix_num_digits)
-        os.makedirs(os.path.join(args.output_dir, f'healpix={healpix}'), exist_ok=True)
+        os.makedirs(os.path.join(args.output_dir, f'ps1_sne_ia/healpix={healpix}'), exist_ok=True)
 
     # Save data as hdf5 grouped into directories by healpix
     for i in range(num_examples):
         healpix = str(metadata['healpix'][i]).zfill(healpix_num_digits)
         object_id = metadata['object_id'][i]
-        path = os.path.join(args.output_dir, f'healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
+        path = os.path.join(args.output_dir, f'ps1_sne_ia/healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
         
         with h5py.File(path, 'w') as hdf5_file:
             # Determine which keys are used for dynamically used metadata

--- a/scripts/ps1_sne_ia/ps1_sne_ia.py
+++ b/scripts/ps1_sne_ia/ps1_sne_ia.py
@@ -64,7 +64,7 @@ _HOMEPAGE = "https://iopscience.iop.org/article/10.3847/1538-4357/aab9bb/pdf"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _STR_FEATURES = [
     "object_id",
@@ -72,8 +72,6 @@ _STR_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "ra", 
-    "dec", 
     "redshift",
     "host_log_mass"
 ]
@@ -88,7 +86,7 @@ class PS1SNIa(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="ps1_sne_ia",
             version=VERSION,
-        data_files=DataFilesPatternsDict.from_patterns({"train": ["./healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+        data_files=DataFilesPatternsDict.from_patterns({"train": ["ps1_sne_ia/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
             description="Light curves from Pan-STARRS1 (PS1)",
         ),
     ]

--- a/scripts/ps1_sne_ia/test.sh
+++ b/scripts/ps1_sne_ia/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download the dataset
-if python download_data.py --destination_path ./ps1_sne_ia; then
+if python download_data.py --destination_path ./ps1_sne_ia_data; then
     echo "Download PS1 SNe Ia dataset successful"
 else
     echo "Download PS1 SNe Ia dataset failed"
@@ -9,7 +9,7 @@ else
 fi
 
 # First build the parent sample and save both raw and H5 to current directory
-if python build_parent_sample.py ./ps1_sne_ia ./ --tiny; then
+if python build_parent_sample.py ./ps1_sne_ia_data . --tiny; then
     echo "Build parent sample for PS1 SNe Ia successful"
 else
     echo "Build parent sample for PS1 SNe Ia failed"

--- a/scripts/sdss/sdss.py
+++ b/scripts/sdss/sdss.py
@@ -124,7 +124,11 @@ class SDSS(datasets.GeneratorBasedBuilder):
             name="all",
             version=VERSION,
             data_files=DataFilesPatternsDict.from_patterns(
-                {"train": ["*/healpix=*/*.hdf5"]}
+                {"train": ["sdss/healpix=*/*.hdf5",
+                           "segue1/healpix=*/*.hdf5",
+                           "segue2/healpix=*/*.hdf5",
+                           "boss/healpix=*/*.hdf5",
+                           "eboss/healpix=*/*.hdf5"]}
             ),
             description="All SDSS-IV spectra.",
         ),

--- a/scripts/snls/build_parent_sample.py
+++ b/scripts/snls/build_parent_sample.py
@@ -137,13 +137,13 @@ def main(args):
     healpix_num_digits = len(str(hp.nside2npix(_healpix_nside)))
     for healpix in unique_healpix:
         healpix = str(healpix).zfill(healpix_num_digits)
-        os.makedirs(os.path.join(args.output_dir, f'healpix={healpix}'), exist_ok=True)
+        os.makedirs(os.path.join(args.output_dir, f'data/healpix={healpix}'), exist_ok=True)
 
     # Save data as hdf5 grouped into directories by healpix
     for i in range(num_examples):
         healpix = str(metadata['healpix'][i]).zfill(healpix_num_digits)
         object_id = metadata['object_id'][i]
-        path = os.path.join(args.output_dir, f'healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
+        path = os.path.join(args.output_dir, f'data/healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
         
         with h5py.File(path, 'w') as hdf5_file:
             # Determine which keys are used for dynamically used metadata

--- a/scripts/snls/snls.py
+++ b/scripts/snls/snls.py
@@ -61,7 +61,7 @@ _HOMEPAGE = "https://www.aanda.org/articles/aa/full_html/2010/15/aa14468-10/aa14
 
 _LICENSE = "GNU General Public License v3.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _STR_FEATURES = [
     "object_id",
@@ -69,8 +69,6 @@ _STR_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "ra", 
-    "dec", 
     "redshift",
     "host_log_mass"
 ]
@@ -85,7 +83,7 @@ class SNLS(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="snls",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["./healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["data/healpix=*/*.hdf5"]}), 
             description="Light curves from SNLS",
         ),
     ]

--- a/scripts/ssl_legacysurvey/ssl_legacysurvey.py
+++ b/scripts/ssl_legacysurvey/ssl_legacysurvey.py
@@ -66,7 +66,7 @@ _HOMEPAGE = "https://github.com/georgestein/ssl-legacysurvey"
 # TODO: Add the licence for the dataset here if you can find it
 _LICENSE = "MIT License"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
     'ebv',
@@ -92,7 +92,7 @@ class SSLLegacySurvey(datasets.GeneratorBasedBuilder):
             name="stein_et_al",
             version=VERSION,
             data_files=DataFilesPatternsDict.from_patterns(
-                {"train": ["*/healpix=*/*.hdf5"]}
+                {"train": ["north/healpix=*/*.hdf5"]}
             ),
             description="DR9 Legacy Survey images from the Stein et al. sample",
         ),        

--- a/scripts/swift_sne_ia/build_parent_sample.py
+++ b/scripts/swift_sne_ia/build_parent_sample.py
@@ -137,13 +137,13 @@ def main(args):
     healpix_num_digits = len(str(hp.nside2npix(_healpix_nside)))
     for healpix in unique_healpix:
         healpix = str(healpix).zfill(healpix_num_digits)
-        os.makedirs(os.path.join(args.output_dir, f'healpix={healpix}'), exist_ok=True)
+        os.makedirs(os.path.join(args.output_dir, f'data/healpix={healpix}'), exist_ok=True)
 
     # Save data as hdf5 grouped into directories by healpix
     for i in range(num_examples):
         healpix = str(metadata['healpix'][i]).zfill(healpix_num_digits)
         object_id = metadata['object_id'][i]
-        path = os.path.join(args.output_dir, f'healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
+        path = os.path.join(args.output_dir, f'data/healpix={healpix}', object_id.decode('utf-8')+'.hdf5')
         
         with h5py.File(path, 'w') as hdf5_file:
             # Determine which keys are used for dynamically used metadata

--- a/scripts/swift_sne_ia/swift_sne_ia.py
+++ b/scripts/swift_sne_ia/swift_sne_ia.py
@@ -60,7 +60,7 @@ _HOMEPAGE = "https://pbrown801.github.io/SOUSA"
 
 _LICENSE = "GNU LESSER GENERAL PUBLIC LICENSE"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _STR_FEATURES = [
     "object_id",
@@ -68,8 +68,6 @@ _STR_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "ra", 
-    "dec", 
     "redshift",
     "host_log_mass"
 ]
@@ -84,7 +82,7 @@ class SwiftSNIa(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="swift_sne_ia",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["./healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["data/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
             description="Light curves from Swift SNe Ia",
         ),
     ]

--- a/scripts/tess/tess.py
+++ b/scripts/tess/tess.py
@@ -42,7 +42,7 @@ _HOMEPAGE = "https://archive.stsci.edu/hlsp/tess-spoc"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 # Full list of features available here:
 # https://archive.stsci.edu/files/live/sites/mast/files/home/missions-and-data/active-missions/tess/_documents/EXP-TESS-ARC-ICD-TM-0014-Rev-F.pdf

--- a/scripts/vipers/build_parent_sample.py
+++ b/scripts/vipers/build_parent_sample.py
@@ -77,10 +77,7 @@ def extract_data(filename):
 
     # Loop through the header keys and add them to the results dictionary
     for key in HEADER_KEYS:
-        if key == "REDSHIFT":
-            results["z"] = float(header[key])
-        else:
-            results[key] = float(header[key])
+        results[key] = float(header[key])
     
     # Add the spectrum data to the results dictionary
     results['spectrum_flux'] = data['FLUXES'].astype(np.float32)
@@ -115,7 +112,7 @@ def save_in_standard_format(results: Table, survey_subdir: str, nside: int):
 
         with h5py.File(output_path, 'w') as output_file:
             for key in keys:
-                output_file.create_dataset(key.lower(), data=grouped_data[key])
+                output_file.create_dataset(key.lower() if key in ['RA', 'DEC'] else key, data=grouped_data[key])
             output_file.create_dataset('object_id', data=grouped_data['ID'])
             output_file.create_dataset('healpix', data=np.full(grouped_data['ID'].shape, index))
 

--- a/scripts/vipers/vipers.py
+++ b/scripts/vipers/vipers.py
@@ -56,32 +56,31 @@ _LICENSE = ""
 _VERSION = "1.0.0"
 
 _FLOAT_FEATURES = [
-    'ra',
-    'dec',
-    'z', 
-    'redflag', 
-    'exptime', 
-    'norm', 
-    'mag'
+    'REDSHIFT', 
+    'REDFLAG', 
+    'EXPTIME', 
+    'NORM', 
+    'MAG'
 ]
 
 class VIPERS(datasets.GeneratorBasedBuilder):
     """VIPERS Full Catalog"""
 
-    VERSION = datasets.Version("1.1.0")
+    VERSION = datasets.Version("1.0.0")
 
     BUILDER_CONFIGS = [
         datasets.BuilderConfig(name="vipers_w1",
                                version=VERSION,
-                               data_files=DataFilesPatternsDict.from_patterns({'train': ['./vipers_w1/healpix=*/*.h5']}),
+                               data_files=DataFilesPatternsDict.from_patterns({'train': ['vipers_w1/healpix=*/*.h5']}),
                                description="VIPERS W1 Catalog"),
         datasets.BuilderConfig(name="vipers_w4",
                                version=VERSION,
-                               data_files=DataFilesPatternsDict.from_patterns({'train': ['./vipers_w4/healpix=*/*.h5']}),
+                               data_files=DataFilesPatternsDict.from_patterns({'train': ['vipers_w4/healpix=*/*.h5']}),
                                description="VIPERS W4 Catalog"),
         datasets.BuilderConfig(name="all",
                                version=VERSION,
-                               data_files=DataFilesPatternsDict.from_patterns({'train': ['./*/healpix=*/*.h5']}),
+                               data_files=DataFilesPatternsDict.from_patterns({'train': ['vipers_w1/healpix=*/*.h5', 
+                                                                                         'vipers_w4/healpix=*/*.h5']}),
                                description="VIPERS Full Catalog")
     ]
 
@@ -101,7 +100,7 @@ class VIPERS(datasets.GeneratorBasedBuilder):
         )
 
         for key in _FLOAT_FEATURES:
-            features[key] = datasets.Value("float64")
+            features[key] = datasets.Value("float32")
 
         features['object_id'] = Value(dtype="string")
 
@@ -153,7 +152,7 @@ class VIPERS(datasets.GeneratorBasedBuilder):
                     }
 
                     for key in _FLOAT_FEATURES:
-                        example[key] = data[key][i].astype(np.float64)
+                        example[key] = data[key][i].astype(np.float32)
 
                     # Add object id
                     example["object_id"] = str(data["object_id"][i])

--- a/scripts/yse/build_parent_sample.py
+++ b/scripts/yse/build_parent_sample.py
@@ -144,13 +144,13 @@ def main(args):
     healpix_num_digits = len(str(hp.nside2npix(_healpix_nside)))
     for healpix in unique_healpix:
         healpix = str(healpix).zfill(healpix_num_digits)
-        os.makedirs(os.path.join(args.output_dir, f'healpix={healpix}'), exist_ok=True)
+        os.makedirs(os.path.join(args.output_dir, f'yse_dr1/healpix={healpix}'), exist_ok=True)
 
     # Save data as hdf5 grouped into directories by healpix
     for i in range(num_examples):
         healpix = str(metadata['healpix'][i]).zfill(healpix_num_digits)
         object_id = metadata['object_id'][i]
-        path = os.path.join(args.output_dir, f'healpix={healpix}', f'{object_id}.hdf5')
+        path = os.path.join(args.output_dir, f'yse_dr1/healpix={healpix}', f'{object_id}.hdf5')
         
         with h5py.File(path, 'w') as hdf5_file:
             # Determine which keys are used for dynamically used metadata
@@ -186,7 +186,7 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Extract YSE data and convert to standard time-series data format.')
     parser.add_argument('--yse_data_path', type=str, help='Path to the local copy of the YSE DR1 data', default='./yse_data_orig')
-    parser.add_argument('--output_dir', type=str, help='Path to the output directory', default='./yse_data')
+    parser.add_argument('--output_dir', type=str, help='Path to the output directory', default='.')
     parser.add_argument('--tiny', action="store_true", help='Use a small subset of the data for testing')
     parser.add_argument('--dirty', action="store_true", help='Do not remove the original data')
     args = parser.parse_args()

--- a/scripts/yse/test.sh
+++ b/scripts/yse/test.sh
@@ -23,6 +23,3 @@ else
     echo "Load dataset for YSE failed"
     exit 1
 fi
-
-# Remove data used for testing
-rm -r ./yse_data

--- a/scripts/yse/yse.py
+++ b/scripts/yse/yse.py
@@ -140,7 +140,7 @@ _HOMEPAGE = "https://zenodo.org/records/7317476"
 
 _LICENSE = "CC BY 4.0"
 
-_VERSION = "0.0.1"
+_VERSION = "1.0.0"
 
 _STR_FEATURES = [
     "object_id",
@@ -148,8 +148,6 @@ _STR_FEATURES = [
 ]
 
 _FLOAT_FEATURES = [
-    "ra", 
-    "dec", 
     "redshift",
     "host_log_mass"
 ]
@@ -164,7 +162,7 @@ class YSEDR1(datasets.GeneratorBasedBuilder):
         datasets.BuilderConfig(
             name="yse_dr1",
             version=VERSION,
-            data_files=DataFilesPatternsDict.from_patterns({"train": ["./yse_data/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
+            data_files=DataFilesPatternsDict.from_patterns({"train": ["yse_dr1/healpix=*/*.hdf5"]}), # This seems fairly inflexible. Probably a massive failure point.
             description="Light curves from YSE DR1",
         ),
     ]


### PR DESCRIPTION
This PR implements a number of consistency fixes to enable the automated upload to HuggingFace. 

These modifications have been tested, and the HF previews are being updated.

#### No renaming/reformatting of native fields

Apart from ra, dec, object_id, image, spectrum, lightcurve, **we do not rename variables from the original surveys**, not even to normalize redshift between Z, z, 'redshift'. 

This is important because **we do not provide documentation for what these fields mean**, and instead direct the user to the original survey documentation. There is no such thing as a "redshift" for instance, any redshift measurement is the output of some algorithm, same for magnitude and such. It is important that the user go back to the survey-specific definition, otherwise we need to do a lot more work to add these descriptions ourselves.

#### Reversionning all datasets to 1.0.0

When  we make updates after this, we can incrementally increase this version number