### PR TITLE
fix missing bz2 for fitsio install in GH action

### DIFF
--- a/.github/workflows/tiny_dset_test.yml
+++ b/.github/workflows/tiny_dset_test.yml
@@ -28,6 +28,7 @@ jobs:
           cache-dependency-path: "**/*requirements*.txt"
       - name: Install dependencies
         run: |
+          sudo apt-get install -y libbz2-dev
           python -m pip install --upgrade pip
           pip install flake8 pytest
           pip install -r dset-requirements.txt


### PR DESCRIPTION
This is causing the action to fail in the dependency install stage before any real tests are run.